### PR TITLE
Enable Building for Swift 5.7

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: maxim-lobanov/setup-xcode@v1
       with:
-        xcode-version: latest-stable
+        xcode-version: 14.2
     - name: Check environment
       run: |
           xcodebuild -version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: maxim-lobanov/setup-xcode@v1
       with:
-        xcode-version: latest-stable
+        xcode-version: 14.2
     - name: Check environment
       run: |
           xcodebuild -version

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.8
+// swift-tools-version:5.7
 import PackageDescription
 
 

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ The primary *ResearchKit framework* codebase supports *iOS* and requires *Xcode 
 *ResearchKit framework* has a *Base SDK* version of *8.0*, meaning that apps using the *ResearchKit
 framework* can run on devices with *iOS 8.0* or newer.
 
-Integrating the ResearchKit framework using the [Swift Package Manager](https://www.swift.org/package-manager/) requires Xcode 14.3 and Swift 5.8 or newer.
+Integrating the ResearchKit framework using the [Swift Package Manager](https://www.swift.org/package-manager/) requires Xcode 14.2 and Swift 5.7 or newer.
 
 Note: You can also import *ResearchKit* into your project using a
  [alternative installation](./docs-standalone/alternative-installation.md) such as *CocoaPods*, *Carthage*, or as a dynamic framework using previous Xcode versions.


### PR DESCRIPTION
# Enable Building for Swift 5.7

## :recycle: Current situation & Problem
- Currently only supports Swift 5.8 or higher

## :bulb: Proposed solution
- Updates the CI to support Xcode 14.2 and Swift 5.7

### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).

