### PR TITLE
Ensure compatibility with C++ interoperability in Swift

### DIFF
--- a/ResearchKit.xcodeproj/project.pbxproj
+++ b/ResearchKit.xcodeproj/project.pbxproj
@@ -222,7 +222,6 @@
 		511B8AA8293A764900049947 /* ORKTouchAbilityTrial.m in Sources */ = {isa = PBXBuildFile; fileRef = 511B8AA6293A764900049947 /* ORKTouchAbilityTrial.m */; };
 		511B8AAA293A766300049947 /* ORKTouchAbilityTrial_Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = 511B8AA9293A766300049947 /* ORKTouchAbilityTrial_Internal.h */; };
 		511B8AAD293A767C00049947 /* ORKTouchAbilityTouchTracker.m in Sources */ = {isa = PBXBuildFile; fileRef = 511B8AAB293A767C00049947 /* ORKTouchAbilityTouchTracker.m */; };
-		511B8AAE293A767C00049947 /* ORKTouchAbilityTouchTracker.h in Headers */ = {isa = PBXBuildFile; fileRef = 511B8AAC293A767C00049947 /* ORKTouchAbilityTouchTracker.h */; };
 		511B8AB1293A76A100049947 /* ORKTouchAbilityTapStep.m in Sources */ = {isa = PBXBuildFile; fileRef = 511B8AAF293A76A100049947 /* ORKTouchAbilityTapStep.m */; };
 		511B8AB2293A76A100049947 /* ORKTouchAbilityTapStep.h in Headers */ = {isa = PBXBuildFile; fileRef = 511B8AB0293A76A100049947 /* ORKTouchAbilityTapStep.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		511B8AB5293A76B200049947 /* ORKTouchAbilityTapStepViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 511B8AB3293A76B200049947 /* ORKTouchAbilityTapStepViewController.m */; };
@@ -1045,9 +1044,9 @@
 		05F3765923C797930068E166 /* ResearchKit.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = ResearchKit.xctestplan; sourceTree = "<group>"; };
 		0B59A6BD28C1738D005035B4 /* ORKPickerTestDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ORKPickerTestDelegate.h; sourceTree = "<group>"; };
 		0B59A6BE28C1738D005035B4 /* ORKPickerTestDelegate.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ORKPickerTestDelegate.m; sourceTree = "<group>"; };
+		0B7D32E92AE6F8040071C576 /* ORKQuestionStepViewController+TestingSupport.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "ORKQuestionStepViewController+TestingSupport.h"; sourceTree = "<group>"; };
 		0B9CC5652A68C02C00080E29 /* UIImageView+ResearchKit.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "UIImageView+ResearchKit.h"; sourceTree = "<group>"; };
 		0B9CC5662A68C02C00080E29 /* UIImageView+ResearchKit.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "UIImageView+ResearchKit.m"; sourceTree = "<group>"; };
-		0B7D32E92AE6F8040071C576 /* ORKQuestionStepViewController+TestingSupport.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "ORKQuestionStepViewController+TestingSupport.h"; sourceTree = "<group>"; };
 		0BA0F4B12A1C1FD300A55672 /* ORKHealthKitQuestionStepViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ORKHealthKitQuestionStepViewControllerTests.swift; sourceTree = "<group>"; };
 		0BAF9796291088ED00EF138A /* ORKNormalizedReactionTimeResult.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ORKNormalizedReactionTimeResult.h; sourceTree = "<group>"; };
 		0BAF9797291088EE00EF138A /* ORKNormalizedReactionTimeStimulusView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ORKNormalizedReactionTimeStimulusView.h; sourceTree = "<group>"; };
@@ -5529,6 +5528,7 @@
 				PRODUCT_NAME = "";
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
+				SWIFT_OBJC_INTEROP_MODE = objc;
 				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
@@ -5539,6 +5539,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				PRODUCT_NAME = "";
 				SKIP_INSTALL = YES;
+				SWIFT_OBJC_INTEROP_MODE = objc;
 				SWIFT_OPTIMIZATION_LEVEL = "-O";
 				SWIFT_VERSION = 5.0;
 			};

--- a/ResearchKit/ActiveTasks/EyeActivitySlider.swift
+++ b/ResearchKit/ActiveTasks/EyeActivitySlider.swift
@@ -73,8 +73,8 @@ internal class EyeActivitySlider: UIView {
     private var slider: CircleSlider?
     
     internal init(testType: VisionStepType) {
-        super.init(frame: CGRect())
-        
+        super.init(frame: .zero)
+
         self.testType = testType
         commonInit()
     }
@@ -112,7 +112,7 @@ internal class EyeActivitySlider: UIView {
         
         letterAngle = Double(letterAngles[Int(arc4random_uniform(7))])
         letterImageView.transform = CGAffineTransform.identity
-        letterImageView.frame = CGRect(origin: CGPoint(), size: CGSize(width: letterSize, height: letterSize))
+        letterImageView.frame = CGRect(origin: .zero, size: CGSize(width: letterSize, height: letterSize))
         letterImageView.center = CGPoint(x: bounds.size.width / 2, y: bounds.size.height / 2)
         letterImageView.transform = CGAffineTransform(rotationAngle: CGFloat(Math.degreesToRadians(letterAngle)))
         letterImageView.alpha = getAlpha()

--- a/ResearchKit/ActiveTasks/ORKLandoltCStepContentView.swift
+++ b/ResearchKit/ActiveTasks/ORKLandoltCStepContentView.swift
@@ -37,7 +37,7 @@ internal class ORKLandoltCStepContentView: UIView {
     private var testType: VisionStepType?
     
     internal init(testType: VisionStepType) {
-        super.init(frame: CGRect())
+        super.init(frame: .zero)
         translatesAutoresizingMaskIntoConstraints = false
         
         self.testType = testType

--- a/ResearchKit/Common/ORKHelpers_Internal.h
+++ b/ResearchKit/Common/ORKHelpers_Internal.h
@@ -385,8 +385,8 @@ ORK_INLINE UIColor *ORKOpaqueColorWithReducedAlphaFromBaseColor(UIColor *baseCol
 }
 
 // Localization
-ORK_EXTERN NSBundle *ORKBundle(void) ORK_AVAILABLE_DECL;
-ORK_EXTERN NSBundle *ORKDefaultLocaleBundle(void);
+extern NSBundle *ORKBundle(void) ORK_AVAILABLE_DECL;
+extern NSBundle *ORKDefaultLocaleBundle(void);
 
 ORK_INLINE NSString *ORKLocalizedHiddenString(NSString *key) {
     // try to find on hidden table
@@ -409,6 +409,6 @@ ORKLocalizedHiddenString(key)
 #define ORKLocalizedStringFromNumber(number) \
 [NSNumberFormatter localizedStringFromNumber:number numberStyle:NSNumberFormatterNoStyle]
 
-NSString* ORKSwiftLocalizedString(NSString *key, NSString *comment);
+ORK_EXTERN NSString* ORKSwiftLocalizedString(NSString *key, NSString *comment);
 
 NS_ASSUME_NONNULL_END

--- a/ResearchKit/Common/ORKPermissionType.h
+++ b/ResearchKit/Common/ORKPermissionType.h
@@ -31,6 +31,7 @@
 @import Foundation;
 
 #import <ResearchKit/ORKDefines.h>
+#import <UserNotifications/UNUserNotificationCenter.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -42,7 +43,6 @@ NS_ASSUME_NONNULL_BEGIN
 @class ORKRequestPermissionView;
 @class HKSampleType, HKObjectType;
 
-typedef NS_OPTIONS(NSUInteger, UNAuthorizationOptions);
 typedef NSString * SRSensor NS_TYPED_ENUM API_AVAILABLE(ios(14.0));
 
 ORK_CLASS_AVAILABLE


### PR DESCRIPTION
# Ensure compatibility with C++ interoperability in Swift

## :recycle: Current situation & Problem

Currently, ResearchKit fails to build when you have a project that enables C++ interoperability in Swift. This PR addresses these issues with some minor code changes.

## :gear: Release Notes 
* Ensure compatibility with C++ interoperability in Swift


## :books: Documentation
--


## :white_check_mark: Testing
Manually verified that SpeziQuestionnaire builds and tests with these changes (with and without C++ interoperability enabled).


### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).
