### PR TITLE
Disable SensorKit support by default

### DIFF
--- a/ResearchKit/ActiveTasks/ORKSwiftStroopContentView.swift
+++ b/ResearchKit/ActiveTasks/ORKSwiftStroopContentView.swift
@@ -28,7 +28,7 @@
  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#if TARGET_OS_IOS
+#if os(iOS)
 
 
 internal class ORKSwiftStroopContentView: ORKActiveStepCustomView {

--- a/ResearchKit/ActiveTasks/ORKSwiftStroopResult.swift
+++ b/ResearchKit/ActiveTasks/ORKSwiftStroopResult.swift
@@ -28,7 +28,7 @@
  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#if TARGET_OS_IOS
+#if os(iOS)
 
 
 import ResearchKit.Private

--- a/ResearchKit/ActiveTasks/ORKSwiftStroopStep.swift
+++ b/ResearchKit/ActiveTasks/ORKSwiftStroopStep.swift
@@ -28,7 +28,7 @@
  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#if TARGET_OS_IOS
+#if os(iOS)
 
 
 import Foundation

--- a/ResearchKit/ActiveTasks/ORKSwiftStroopStepViewController.swift
+++ b/ResearchKit/ActiveTasks/ORKSwiftStroopStepViewController.swift
@@ -28,7 +28,7 @@
  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#if TARGET_OS_IOS
+#if os(iOS)
 
 
 import ResearchKit.Private


### PR DESCRIPTION
# Disable SensorKit support by default

## :recycle: Current situation & Problem
As discussed in #17, SensorKit is not available on iPadOS even though it is annotated to be available. This results SensorKit being linked for iOS but the app crashing when run on iPad as the framework cannot be dynamically linked.
This issue was induced due to the change in #16 that raised the deployment target to iOS 15. Even conditionally importing SensorKit does not work as it is reported to be available for iPadOS to the compiler.

This PR disables SensorKit integration by default, controlled via the `USE_SENSOR_KIT` macro. While the `ORKSensorPermissionType` is still there it shows up as unavailable for the platform in ResearchKit UI. 

## :gear: Release Notes 
* Fixed crash on iPadOS by disabling SensorKit integration by default.


## :books: Documentation
--


## :white_check_mark: Testing
Verified locally.


### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).
