### PR TITLE
Fix access to UIWindow when delegate doesn't implement that property

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,7 @@ jobs:
             cxxInterop: true
     with:
       workspaceFile: RKWorkspace.xcworkspace
-      xcArchiveName: ResearchKit
+      xcArchiveName: ResearchKit-${{ matrix.configuration }}
       scheme: ResearchKit
       version: ${{ inputs.version }}
       configuration: ${{ matrix.configuration }}

--- a/ResearchKit/ActiveTasks/ORKNormalizedReactionTimeContentView.m
+++ b/ResearchKit/ActiveTasks/ORKNormalizedReactionTimeContentView.m
@@ -78,7 +78,12 @@ CGFloat BackgroundViewSpaceMultiplier = 2.0;
 }
 
 -(void)resizeConstraints {
-    ORKScreenType screenType = ORKGetVerticalScreenTypeForWindow([[[UIApplication sharedApplication] delegate] window]);
+    ORKScreenType screenType;
+    if ([[UIApplication sharedApplication].delegate respondsToSelector:@selector(window)]) {
+        screenType = ORKGetVerticalScreenTypeForWindow([[[UIApplication sharedApplication] delegate] window]);
+    } else {
+        screenType = ORKGetVerticalScreenTypeForWindow(NULL);
+    }
     if (screenType == ORKScreenTypeiPhone5 ) {
         NormalizeButtonSize = 70.0;
         BackgroundViewSpaceMultiplier = 1.75;

--- a/ResearchKit/ActiveTasks/ORKStroopContentView.m
+++ b/ResearchKit/ActiveTasks/ORKStroopContentView.m
@@ -62,8 +62,13 @@ static const CGFloat buttonStackViewSpacing = 20.0;
         [_colorLabel setFont:[UIFont systemFontOfSize:60]];
         [_colorLabel setAdjustsFontSizeToFitWidth:YES];
         
-        ORKScreenType screenType = ORKGetVerticalScreenTypeForWindow([[[UIApplication sharedApplication] delegate] window]);
-        
+        ORKScreenType screenType;
+        if ([[UIApplication sharedApplication].delegate respondsToSelector:@selector(window)]) {
+            screenType = ORKGetVerticalScreenTypeForWindow([[[UIApplication sharedApplication] delegate] window]);
+        } else {
+            screenType = ORKGetVerticalScreenTypeForWindow(NULL);
+        }
+
         if (screenType == ORKScreenTypeiPhone5 ) {
             labelWidth = 200.0;
             labelHeight = 200.0;
@@ -145,8 +150,13 @@ static const CGFloat buttonStackViewSpacing = 20.0;
         
         _buttonStackView.axis = UILayoutConstraintAxisVertical;
         
-        ORKScreenType screenType = ORKGetVerticalScreenTypeForWindow([[[UIApplication sharedApplication] delegate] window]);
-        
+        ORKScreenType screenType;
+        if ([[UIApplication sharedApplication].delegate respondsToSelector:@selector(window)]) {
+            screenType = ORKGetVerticalScreenTypeForWindow([[[UIApplication sharedApplication] delegate] window]);
+        } else {
+            screenType = ORKGetVerticalScreenTypeForWindow(NULL);
+        }
+
         if (screenType == ORKScreenTypeiPhone6) {
             minimumButtonHeight = 150.0;
         } else if (screenType == ORKScreenTypeiPhone5 ) {


### PR DESCRIPTION
# Fix access to UIWindow when delegate doesn't implement that property

## :recycle: Current situation & Problem
Currently, ResearchKit assumes that the `window` property is implemented by every `UIApplicationDelegate`. However, if you refer to the documentation of [window](https://developer.apple.com/documentation/uikit/uiapplicationdelegate/1623056-window) the property is only required if you are using UIKit with Storyboard files. The automatic synthesis the documentation refers to doesn't seem to work according to our experience.
This issue impacted, e.g., https://github.com/CS342/2024-PICS/pull/43.

This PR fixes this issue by checking first, if the respective delegate instance responds to the window selector.

This PR also addresses an issue in the CI setup where artifact names where not unique and therefore failed the CI run.


## :gear: Release Notes 
* Fixes a crash where `window` is not implemented for an UIApplicationDelegate.


## :books: Documentation
--


## :white_check_mark: Testing
This will be verified within #20. However, the PR requires to compiled ResearchKit xcfamework first.


### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).
