### PR TITLE
Fix Endless Loop for Tint Color Changes

### DIFF
--- a/ResearchKit/Common/ORKCheckmarkView.m
+++ b/ResearchKit/Common/ORKCheckmarkView.m
@@ -105,22 +105,14 @@ static const CGFloat CheckmarkViewBorderWidth = 2.0;
 - (void)updateCheckView {
     if (_checked) {
         self.image = _checkedImage;
-        //        FIXME: Need to be replaced.
-        if (@available(iOS 13.0, *)) {
+        if (![self.tintColor isEqual: ORKViewTintColor(self)]) {
             self.tintColor = ORKViewTintColor(self);
-        } else {
-            self.backgroundColor = [self tintColor];
-            self.tintColor = UIColor.whiteColor;
         }
     }
     else {
         self.image = _uncheckedImage;
-        if (@available(iOS 13.0, *)) {
+        if (![self.tintColor isEqual: [UIColor systemGray3Color]]) {
             self.tintColor = [UIColor systemGray3Color];
-        } else {
-            self.tintColor = nil;
-            self.image = nil;
-            self.backgroundColor = UIColor.clearColor;
         }
     }
 }


### PR DESCRIPTION
# Fix Endless Loop for Tint Color Changes

## :recycle: Current situation & Problem
We have received crash reports in our Spezi Study App and have pinned it down to a ResearchKit endless loop:
<img width="1296" alt="Screenshot 2024-03-15 at 11 47 49 AM" src="https://github.com/StanfordBDHG/ResearchKit/assets/28656495/bf0960b1-39b1-417d-8a84-65e7a2c1674d">

## :gear: Release Notes 
- Avoids to break the endless loop by improving the change notification for tint color changes.

### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).
