### PR TITLE
Support extensions points to handle ResearchKit lifecycle events within SwiftUI

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -22,18 +22,19 @@ jobs:
   create-xcframework-and-release-workflow:
     uses: StanfordBDHG/.github/.github/workflows/xcframework.yml@v2
     with:
+      runsonlabels: '["macOS", "self-hosted"]'
       workspaceFile: RKWorkspace.xcworkspace
       xcFrameworkName: ResearchKit
       scheme: ResearchKit
       dryRun: true
       version: ${{ inputs.version }}
       configuration: Release
-      runsonlabels: '["macOS", "self-hosted"]'
       sdk: '["iphoneos", "iphonesimulator", "xros", "xrsimulator"]'
   ios:
     name: Build and Test iOS
     uses: StanfordBDHG/.github/.github/workflows/xcodebuild-or-fastlane.yml@v2
     with:
+      runsonlabels: '["macOS", "self-hosted"]'
       path: 'Tests/UITests'
       scheme: TestApp
       resultBundle: TestApp-iOS.xcresult

--- a/ResearchKit/PrivateHeaders/ResearchKit_Private.h
+++ b/ResearchKit/PrivateHeaders/ResearchKit_Private.h
@@ -183,8 +183,3 @@
 
 #import <ResearchKit/ORKLearnMoreView.h>
 #import <ResearchKit/ORKBodyContainerView.h>
-
-
-// Manual additions
-#import <ResearchKit/ORKAnswerFormat_Internal.h>
-#import <ResearchKit/ORKFormStep_Internal.h>

--- a/ResearchKit/PrivateHeaders/ResearchKit_Private.h
+++ b/ResearchKit/PrivateHeaders/ResearchKit_Private.h
@@ -183,3 +183,8 @@
 
 #import <ResearchKit/ORKLearnMoreView.h>
 #import <ResearchKit/ORKBodyContainerView.h>
+
+
+// Manual additions
+#import <ResearchKit/ORKAnswerFormat_Internal.h>
+#import <ResearchKit/ORKFormStep_Internal.h>

--- a/ResearchKit/ResearchKit.h
+++ b/ResearchKit/ResearchKit.h
@@ -163,5 +163,3 @@
 
 #import <ResearchKit/ORKEarlyTerminationConfiguration.h>
 #import <ResearchKit/ORKBundleAsset.h>
-
-

--- a/Sources/ResearchKitSwiftUI/ORKLifecycle.swift
+++ b/Sources/ResearchKitSwiftUI/ORKLifecycle.swift
@@ -18,6 +18,10 @@ private struct ORKWillDisappearMethod: EnvironmentKey {
     static let defaultValue: ((ORKTaskViewController, ORKStepViewController, ORKStepViewControllerNavigationDirection) -> Void)? = nil
 }
 
+private struct ORKShouldPresentMethod: EnvironmentKey {
+    static let defaultValue: ((ORKTaskViewController, ORKStep) -> Bool)? = nil
+}
+
 
 extension EnvironmentValues {
     var onStepWillAppear: ((ORKTaskViewController, ORKStepViewController) -> Void)? {
@@ -37,6 +41,15 @@ extension EnvironmentValues {
             self[ORKWillDisappearMethod.self] = newValue
         }
     }
+
+    var shouldPresentStep: ((ORKTaskViewController, ORKStep) -> Bool)? {
+        get {
+            self[ORKShouldPresentMethod.self]
+        }
+        set {
+            self[ORKShouldPresentMethod.self] = newValue
+        }
+    }
 }
 
 
@@ -47,7 +60,7 @@ extension View {
     ///
     /// - Note: This method bridges the [`taskViewController:stepViewControllerWillAppear:`](https://researchkit.org/docs/Protocols/ORKTaskViewControllerDelegate.html#//api/name/taskViewController:stepViewControllerWillAppear:)
     /// of the underlying `ORKTaskViewControllerDelegate` to the SwiftUI environment.
-    /// - Parameter perform: The closure to be execute before the step is presented.
+    /// - Parameter perform: The closure to be executed before the step is presented.
     /// - Returns: The modified view.
     @_spi(ORK)
     public func onStepWillAppear(
@@ -64,12 +77,28 @@ extension View {
     ///
     /// - Note: This method bridges the [`taskViewController:stepViewControllerWillDisappear:navigationDirection:`](https://researchkit.org/docs/Protocols/ORKTaskViewControllerDelegate.html#//api/name/taskViewController:stepViewControllerWillDisappear:navigationDirection:)
     /// of the underlying `ORKTaskViewControllerDelegate` to the SwiftUI environment.
-    /// - Parameter perform: The closure to be execute before the step disappears.
+    /// - Parameter perform: The closure to be executed before the step disappears.
     /// - Returns: The modified view.
     @_spi(ORK)
     public func onStepWillDisappear(
         perform closure: @escaping (ORKTaskViewController, ORKStepViewController, ORKStepViewControllerNavigationDirection) -> Void
     ) -> some View {
         environment(\.onStepWillDisappear, closure)
+    }
+
+
+    /// Adds a predicate to decide if a given step should be presented.
+    ///
+    /// Add a predicate that is called to determine if a step should be presented.
+    /// This is called once the `Continue` button of a previous step is called (or before the first step is shown). When returning `false` nothing happens,
+    /// otherwise the respective view controller for the given step will be shown.
+    ///
+    /// - Note: This method bridges the [`taskViewController:shouldPresentStep:`](https://researchkit.org/docs/Protocols/ORKTaskViewControllerDelegate.html#//api/name/taskViewController:shouldPresentStep:)
+    /// of the underlying `ORKTaskViewControllerDelegate` to the SwiftUI environment.
+    /// - Parameter predicate: The closure to be executed to determine if the next step should be presented.
+    /// - Returns: The modified view.
+    @_spi(ORK) // TODO: docs!
+    public func shouldPresentStep(predicate: @escaping (ORKTaskViewController, ORKStep) -> Bool) -> some View {
+        environment(\.shouldPresentStep, predicate)
     }
 }

--- a/Sources/ResearchKitSwiftUI/ORKLifecycle.swift
+++ b/Sources/ResearchKitSwiftUI/ORKLifecycle.swift
@@ -9,6 +9,8 @@
 import ResearchKit
 import SwiftUI
 
+// swiftlint:disable file_types_order
+
 
 private struct ORKWillAppearMethod: EnvironmentKey {
     static let defaultValue: ((ORKTaskViewController, ORKStepViewController) -> Void)? = nil
@@ -97,7 +99,7 @@ extension View {
     /// of the underlying `ORKTaskViewControllerDelegate` to the SwiftUI environment.
     /// - Parameter predicate: The closure to be executed to determine if the next step should be presented.
     /// - Returns: The modified view.
-    @_spi(ORK) // TODO: docs!
+    @_spi(ORK)
     public func shouldPresentStep(predicate: @escaping (ORKTaskViewController, ORKStep) -> Bool) -> some View {
         environment(\.shouldPresentStep, predicate)
     }

--- a/Sources/ResearchKitSwiftUI/ORKLifecycle.swift
+++ b/Sources/ResearchKitSwiftUI/ORKLifecycle.swift
@@ -1,0 +1,75 @@
+//
+// This source file is part of the Stanford Biodesign Digital Health Group open-source organization
+//
+// SPDX-FileCopyrightText: 2024 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import ResearchKit
+import SwiftUI
+
+
+private struct ORKWillAppearMethod: EnvironmentKey {
+    static let defaultValue: ((ORKTaskViewController, ORKStepViewController) -> Void)? = nil
+}
+
+private struct ORKWillDisappearMethod: EnvironmentKey {
+    static let defaultValue: ((ORKTaskViewController, ORKStepViewController, ORKStepViewControllerNavigationDirection) -> Void)? = nil
+}
+
+
+extension EnvironmentValues {
+    var onStepWillAppear: ((ORKTaskViewController, ORKStepViewController) -> Void)? {
+        get {
+            self[ORKWillAppearMethod.self]
+        }
+        set {
+            self[ORKWillAppearMethod.self] = newValue
+        }
+    }
+
+    var onStepWillDisappear: ((ORKTaskViewController, ORKStepViewController, ORKStepViewControllerNavigationDirection) -> Void)? {
+        get {
+            self[ORKWillDisappearMethod.self]
+        }
+        set {
+            self[ORKWillDisappearMethod.self] = newValue
+        }
+    }
+}
+
+
+extension View {
+    /// Add an action every time a step appears.
+    ///
+    /// This method adds a closure that is called by the underlying `ORKTaskViewController` once a new step is about to be displayed.
+    ///
+    /// - Note: This method bridges the [`taskViewController:stepViewControllerWillAppear:`](https://researchkit.org/docs/Protocols/ORKTaskViewControllerDelegate.html#//api/name/taskViewController:stepViewControllerWillAppear:)
+    /// of the underlying `ORKTaskViewControllerDelegate` to the SwiftUI environment.
+    /// - Parameter perform: The closure to be execute before the step is presented.
+    /// - Returns: The modified view.
+    @_spi(ORK)
+    public func onStepWillAppear(
+        perform closure: @escaping (ORKTaskViewController, ORKStepViewController) -> Void
+    ) -> some View {
+        environment(\.onStepWillAppear, closure)
+    }
+
+    /// Adds an action every time a step disappears.
+    ///
+    /// Add an action every time a step appears.
+    ///
+    /// This method adds a closure that is called by the underlying `ORKTaskViewController` once a step is about to disappear.
+    ///
+    /// - Note: This method bridges the [`taskViewController:stepViewControllerWillDisappear:navigationDirection:`](https://researchkit.org/docs/Protocols/ORKTaskViewControllerDelegate.html#//api/name/taskViewController:stepViewControllerWillDisappear:navigationDirection:)
+    /// of the underlying `ORKTaskViewControllerDelegate` to the SwiftUI environment.
+    /// - Parameter perform: The closure to be execute before the step disappears.
+    /// - Returns: The modified view.
+    @_spi(ORK)
+    public func onStepWillDisappear(
+        perform closure: @escaping (ORKTaskViewController, ORKStepViewController, ORKStepViewControllerNavigationDirection) -> Void
+    ) -> some View {
+        environment(\.onStepWillDisappear, closure)
+    }
+}

--- a/Sources/ResearchKitSwiftUI/ORKOrderedTaskView.swift
+++ b/Sources/ResearchKitSwiftUI/ORKOrderedTaskView.swift
@@ -58,6 +58,7 @@ public struct ORKOrderedTaskView: UIViewControllerRepresentable {
 
         fileprivate var stepWillAppear: ((ORKTaskViewController, ORKStepViewController) -> Void)?
         fileprivate var stepWillDisappear: ((ORKTaskViewController, ORKStepViewController, ORKStepViewControllerNavigationDirection) -> Void)?
+        fileprivate var shouldPresentStep: ((ORKTaskViewController, ORKStep) -> Bool)?
 
 
         init(
@@ -128,6 +129,10 @@ public struct ORKOrderedTaskView: UIViewControllerRepresentable {
                 }
             }
         }
+
+        public func taskViewController(_ taskViewController: ORKTaskViewController, shouldPresent step: ORKStep) -> Bool {
+            return shouldPresentStep?(taskViewController, step) ?? true
+        }
     }
 
     
@@ -146,6 +151,8 @@ public struct ORKOrderedTaskView: UIViewControllerRepresentable {
     private var onStepWillAppear
     @Environment(\.onStepWillDisappear)
     private var onStepWillDisappear
+    @Environment(\.shouldPresentStep)
+    private var shouldPresentStep
 
 
     private var outputDirectory: URL {
@@ -209,8 +216,7 @@ public struct ORKOrderedTaskView: UIViewControllerRepresentable {
 
     public func makeCoordinator() -> Coordinator {
         let coordinator = Coordinator(result: result, cancelBehavior: cancelBehavior)
-        coordinator.stepWillAppear = onStepWillAppear
-        coordinator.stepWillDisappear = onStepWillDisappear
+        updateClosures(for: coordinator)
         return coordinator
     }
 
@@ -220,8 +226,7 @@ public struct ORKOrderedTaskView: UIViewControllerRepresentable {
 
         context.coordinator.result = result
         context.coordinator.cancelBehavior = cancelBehavior
-        context.coordinator.stepWillAppear = onStepWillAppear
-        context.coordinator.stepWillDisappear = onStepWillDisappear
+        updateClosures(for: context.coordinator)
     }
 
     public func makeUIViewController(context: Context) -> ORKTaskViewController {
@@ -231,5 +236,11 @@ public struct ORKOrderedTaskView: UIViewControllerRepresentable {
         viewController.delegate = context.coordinator
         viewController.outputDirectory = outputDirectory
         return viewController
+    }
+
+    private func updateClosures(for coordinator: Coordinator) {
+        coordinator.stepWillAppear = onStepWillAppear
+        coordinator.stepWillDisappear = onStepWillDisappear
+        coordinator.shouldPresentStep = shouldPresentStep
     }
 }

--- a/Sources/ResearchKitSwiftUI/ORKOrderedTaskView.swift
+++ b/Sources/ResearchKitSwiftUI/ORKOrderedTaskView.swift
@@ -131,7 +131,7 @@ public struct ORKOrderedTaskView: UIViewControllerRepresentable {
         }
 
         public func taskViewController(_ taskViewController: ORKTaskViewController, shouldPresent step: ORKStep) -> Bool {
-            return shouldPresentStep?(taskViewController, step) ?? true
+            shouldPresentStep?(taskViewController, step) ?? true
         }
     }
 

--- a/samples/ORKCatalog/ORKCatalog/Results/ResultTableViewProviders.swift
+++ b/samples/ORKCatalog/ORKCatalog/Results/ResultTableViewProviders.swift
@@ -176,8 +176,10 @@ func resultTableViewProviderForResult(_ result: ORKResult?, delegate: ResultProv
     case is ORKWebViewStepResult:
         providerType = WebViewStepResultTableViewProvider.self
         
-    case is ORKLandoltCResult:
-        providerType = LandoltCStepResultProvider.self
+    // Unfortunately, CoreFoundation types can not be used in public interfaces when using C++ interoperability mode in Swift.
+    // CircleSlider is using these types, and we therefore disabled the Landolt C Visual Acuity Task for now.
+    // case is ORKLandoltCResult:
+    //     providerType = LandoltCStepResultProvider.self
 
     case is ORKEnvironmentSPLMeterResult:
         providerType = SPLMeterStepResultTableViewProvider.self
@@ -1388,6 +1390,10 @@ class WebViewStepResultTableViewProvider: ResultTableViewProvider {
 class LandoltCStepResultProvider: ResultTableViewProvider {
     // MARK: ResultTableViewProvider
     
+    /*
+    // Unfortunately, CoreFoundation types can not be used in public interfaces when using C++ interoperability mode in Swift.
+    // CircleSlider is using these types, and we therefore disabled the Landolt C Visual Acuity Task for now.
+
     override func resultRowsForSection(_ section: Int) -> [ResultRow] {
         let landoltCResult = result as! ORKLandoltCResult
 
@@ -1404,6 +1410,7 @@ class LandoltCStepResultProvider: ResultTableViewProvider {
         
         return rows
     }
+    */
 }
 
 /// Table view provider specific to an `ORKdBHLToneAudiometryResult` instance.


### PR DESCRIPTION
# Support extensions points to handle ResearchKit lifecycle events within SwiftUI

## :recycle: Current situation & Problem
ResearchKit provides extensions points via the TaskViewControllerDelegate to manipulate the behavior of the presented UI or react to certain events (e.g., next step being presented). This is currently not accessible via the SwiftUI wrapper `ORKOrderedTaskView`.
This PR adds several view modifiers under the `ORK` SPI of `ResearchKitSwiftUI` to add actions for `stepWillAppear` and `stepWillDisappear` actions as well as an ability to specify a `shouldPresentStep` predicate. This allows for extensive customization of ResearchKit behavior.


## :gear: Release Notes 
* Provide access lifecycle actions.
* Ability to control if a step should be presented.


## :books: Documentation
Documentation was added for all new interfaces.

### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).
